### PR TITLE
Fix Errore Vecchie Versioni Codice Offuscato

### DIFF
--- a/ver.-0.2/deobfuscator.py
+++ b/ver.-0.2/deobfuscator.py
@@ -54,6 +54,8 @@ if len(sys.argv) > 1:
 		print "*ERROR: Provided a PHP script not obfuscated with FOPO PHP Obfuscator!"
 		sys.exit()
 
+	contents = re.sub('//?\s*\*[\s\S]*?\*\s*//?', '', contents)
+	
 	eval = contents.split('(')
 	
 	#base64 = base64 encoded block inside obfuscated PHP script


### PR DESCRIPTION
Il codice offuscato antecedente al 2016 contiene due parentesi nei commenti, esempio:

"This code was created on Sunday, June 10th, 2015 at XX:XX UTC from IP 111.222.333.444 (ng)"

Tali parentesi non permettono di interpretare correttamente il codice offuscato.

Si è risolto il problema tramite una regex che elimina le righe dei commenti.